### PR TITLE
CLOUD-218 tagging new build with "latest"

### DIFF
--- a/.github/actions/build-and-push-docker-image/action.yml
+++ b/.github/actions/build-and-push-docker-image/action.yml
@@ -31,6 +31,6 @@ runs:
       env:
         AWS_ECR: ${{ inputs.aws_ecr }}
       run: |
-        docker build -t $AWS_ECR/redis-roaring:sha_$GITHUB_SHA .
+        docker build -t $AWS_ECR/redis-roaring:sha_$GITHUB_SHA -t $AWS_ECR/redis-roaring:latest .
         docker push $AWS_ECR/redis-roaring --all-tags
       shell: bash


### PR DESCRIPTION
I'm not 100% sure this is going to work because after I removed the `buildx` portion of the `docker build ... ` command, the image size dropped by ~350MB so we may not be building what we think we're building, but let's try it.