### PR TITLE
CLOUD-1926 artifacts ecr

### DIFF
--- a/.github/actions/build-and-push-docker-image/action.yml
+++ b/.github/actions/build-and-push-docker-image/action.yml
@@ -4,33 +4,43 @@ inputs:
   aws_ecr:
     description: "The ECR base url to push the image into (omit the redis-roaring image name)"
     required: true
+    default: "852894311366.dkr.ecr.us-west-2.amazonaws.com"
   aws_region:
     description: "AWS region"
     default: "us-west-2"
+  environment:
+    description: "The environment for which we're building this image (used in tagging)"
+    required: true
   oidc_role:
+    description: "The AWS IAM Role used to authenticate to AWS via IdentityCenter OIDC"
     type: string
     required: true
 runs:
   using: "composite"
   steps:
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v2
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ inputs.oidc_role }}
-        role-session-name: GithubActions
+        role-session-name: GithubActionsRedisRoaring
         aws-region: ${{ inputs.aws_region }}
+
     - name: Login to Amazon ECR
       id: login_ecr
-      uses: aws-actions/amazon-ecr-login@v1
+      uses: aws-actions/amazon-ecr-login@v2
+
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v3
+
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
+
     - name: Build, tag, and push image to Amazon ECR
       id: build-image
       env:
         AWS_ECR: ${{ inputs.aws_ecr }}
+        ENVIRONMENT: ${{ inputs.environment }}
       run: |
-        docker build -t $AWS_ECR/redis-roaring:sha_$GITHUB_SHA .
+        docker build -t $AWS_ECR/redis-roaring:sha_$GITHUB_SHA -t $AWS_ECR/redis-roaring:${ENVIRONMENT} .
         docker push $AWS_ECR/redis-roaring --all-tags
       shell: bash

--- a/.github/actions/build-and-push-docker-image/action.yml
+++ b/.github/actions/build-and-push-docker-image/action.yml
@@ -8,7 +8,7 @@ inputs:
   aws_region:
     description: "AWS region"
     default: "us-west-2"
-  environment:
+  envtag:
     description: "The environment for which we're building this image (used in tagging)"
     required: true
   oidc_role:
@@ -39,8 +39,8 @@ runs:
       id: build-image
       env:
         AWS_ECR: ${{ inputs.aws_ecr }}
-        ENVIRONMENT: ${{ inputs.environment }}
+        ENV_TAG: ${{ inputs.envtag }}
       run: |
-        docker build -t $AWS_ECR/redis-roaring:sha_$GITHUB_SHA -t $AWS_ECR/redis-roaring:${ENVIRONMENT} .
+        docker build -t $AWS_ECR/redis-roaring:sha_$GITHUB_SHA -t $AWS_ECR/redis-roaring:${ENV_TAG} .
         docker push $AWS_ECR/redis-roaring --all-tags
       shell: bash

--- a/.github/actions/build-and-push-docker-image/action.yml
+++ b/.github/actions/build-and-push-docker-image/action.yml
@@ -2,7 +2,7 @@ name: Build and Push Docker Image
 description: Builds docker image, logs in to ECR and pushes the new image to ECR
 inputs:
   aws_ecr:
-    description: "The ECR base url to push the image into (omit the redis-roaring image name)"
+    description: "The ECR base url to push the image into (omit the redis-roaring image name). Defaults to AWS Artifacts account."
     required: true
     default: "852894311366.dkr.ecr.us-west-2.amazonaws.com"
   aws_region:
@@ -12,7 +12,7 @@ inputs:
     description: "The environment for which we're building this image (used in tagging)"
     required: true
   oidc_role:
-    description: "The AWS IAM Role used to authenticate to AWS via IdentityCenter OIDC"
+    description: "The AWS IAM Role used to authenticate to AWS via IdentityCenter OIDC.  Should have push access to the aws_ecr value."
     type: string
     required: true
 runs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
     name: Build and push to ECR (Staging)
     needs: [configure, test]
     if: github.ref != 'refs/heads/master'
-    environment: staging
+    environment: artifacts
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -43,7 +43,7 @@ jobs:
       - name: Build and Push Docker Image
         uses: ./.github/actions/build-and-push-docker-image
         with:
-          environment: staging
+          envtag: staging
           aws_region: ${{ vars.AWS_REGION }}
           oidc_role: ${{ vars.AWS_GITHUB_OIDC_ROLE }}
 
@@ -66,7 +66,7 @@ jobs:
     name: Build and push to ECR (Production)
     needs: [configure, test, performance]
     if: github.ref == 'refs/heads/master'
-    environment: production
+    environment: artifacts
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -74,7 +74,7 @@ jobs:
       - name: Build and Push Docker Image
         uses: ./.github/actions/build-and-push-docker-image
         with:
-          environment: production
+          envtag: production
           aws_region: ${{ vars.AWS_REGION }}
           oidc_role: ${{ vars.AWS_GITHUB_OIDC_ROLE }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,21 +14,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Configure
       run: ./configure.sh
+
   test:
     name: Test project
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Configure
       run: ./configure.sh
     - name: Install valgrind
       run: sudo apt-get install valgrind
     - name: Test
       run: ./test.sh
+
   build_and_push_staging:
     name: Build and push to ECR (Staging)
     needs: [configure, test]
@@ -37,13 +39,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Build and Push Docker Image
         uses: ./.github/actions/build-and-push-docker-image
         with:
-          aws_ecr: ${{ vars.AWS_ECR }}
+          environment: staging
           aws_region: ${{ vars.AWS_REGION }}
           oidc_role: ${{ vars.AWS_GITHUB_OIDC_ROLE }}
+
   performance:
     name: Performance tests
     needs: [configure, test]
@@ -51,13 +54,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Configure
         run: ./configure.sh
       - name: Install valgrind
         run: sudo apt-get install valgrind
       - name: Test
         run: ./performance.sh
+
   build_and_push_production:
     name: Build and push to ECR (Production)
     needs: [configure, test, performance]
@@ -66,11 +70,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Build and Push Docker Image
         uses: ./.github/actions/build-and-push-docker-image
         with:
-          aws_ecr: ${{ vars.AWS_ECR }}
+          environment: production
           aws_region: ${{ vars.AWS_REGION }}
           oidc_role: ${{ vars.AWS_GITHUB_OIDC_ROLE }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           envtag: staging
           aws_region: ${{ vars.AWS_REGION }}
-          oidc_role: ${{ vars.AWS_GITHUB_OIDC_ROLE }}
+          oidc_role: ${{ vars.OIDC_IAM_ROLE }}
 
   performance:
     name: Performance tests
@@ -76,6 +76,6 @@ jobs:
         with:
           envtag: production
           aws_region: ${{ vars.AWS_REGION }}
-          oidc_role: ${{ vars.AWS_GITHUB_OIDC_ROLE }}
+          oidc_role: ${{ vars.OIDC_IAM_ROLE }}
 
 


### PR DESCRIPTION
Modernizing the various GHA plugins this thing uses and also switches the AWS Account we're pushing the resulting docker image from staging&production to just always be AWS Artifacts

Tested off this branch and it seems to be pushing to our AWS Artfiacts account okay:
<img width="1712" alt="Screenshot 2025-07-08 at 3 29 00 PM" src="https://github.com/user-attachments/assets/53437d15-a6e1-4f67-84b1-373232b53e7d" />
